### PR TITLE
Fix problem in twig

### DIFF
--- a/models/OrderPosition.php
+++ b/models/OrderPosition.php
@@ -301,17 +301,17 @@ class OrderPosition extends Model
 
     /**
      * Get order property value
-     * @param string $sField
+     * @param string|null $sField
      * @return mixed
      */
-    public function getProperty($sField)
+    public function getProperty($sField = null)
     {
         $arPropertyList = $this->property;
         if (empty($arPropertyList) || empty($sField)) {
             return null;
         }
 
-        return array_get($arPropertyList, $sField);
+        return ($sField) ? array_get($arPropertyList, $sField) : $arPropertyList;
     }
 
     /**


### PR DESCRIPTION
When call `obOrderPosition.property` in Twig, if `property` attribute is empty, Twig call `getProperty` method without parameters.