### PR TITLE
Allow payment data to be saved

### DIFF
--- a/models/Order.php
+++ b/models/Order.php
@@ -131,6 +131,7 @@ class Order extends Model
         'currency_id',
         'shipping_tax_percent',
         'manager_id',
+        'payment_data',
     ];
 
     public $cached = [


### PR DESCRIPTION
This fixes oc-shopaholic/oc-shopaholic-plugin#194

I see an intention to store user's input `payment` to `payment_data` field of Order model here.
https://github.com/oc-shopaholic/oc-orders-shopaholic-plugin/blob/master/components/MakeOrder.php#L228

But, it is not actually stored in Order object because `payment_data` field is not specified in `$fillable` array.