### PR TITLE
Add shipping price info to return data of getCartData

### DIFF
--- a/classes/processor/CartProcessor.php
+++ b/classes/processor/CartProcessor.php
@@ -9,6 +9,7 @@ use Lovata\Toolbox\Classes\Helper\UserHelper;
 use Lovata\Shopaholic\Models\Settings;
 use Lovata\OrdersShopaholic\Models\Cart;
 use Lovata\OrdersShopaholic\Models\CartPosition;
+use Lovata\OrdersShopaholic\Classes\Item\ShippingTypeItem;
 use Lovata\OrdersShopaholic\Classes\PromoMechanism\ItemPriceContainer;
 use Lovata\OrdersShopaholic\Classes\PromoMechanism\TotalPriceContainer;
 use Lovata\OrdersShopaholic\Classes\Collection\CartPositionCollection;
@@ -56,11 +57,12 @@ class CartProcessor
     }
 
     /**
-     * Init new cart positions and promo processor
+     * Init new cart positions, shipping type, and promo processor
      */
     public function updateCartData()
     {
         $this->initCartPositionList();
+        $this->initShippingTypeItem();
         $this->initPromoProcessor();
     }
 
@@ -356,6 +358,16 @@ class CartProcessor
         //Create new cart
         if (empty($this->obCart)) {
             $this->createNewCart();
+        }
+    }
+
+    /**
+     * Init selected shipping type
+     */
+    protected function initShippingTypeItem()
+    {
+        if (empty($this->obShippingTypeItem)) {
+            $this->obShippingTypeItem = ShippingTypeItem::make($this->getCartObject()->shipping_type_id);
         }
     }
 


### PR DESCRIPTION
This PR addresses to the issue 1 in oc-shopaholic/oc-shopaholic-plugin#218.

With this PR, the return value of `Cart::onGetData` will include shipping price data, if the cart data in database has valid value in `shipping_type_id` column.
This modification has no side effect, because `CartProcessor::$obShippingTypeItem` won't be overwritten if it is not empty.

I guess that `Cart::onGetData` should include shipping price, because of the following reason.

In the return data of `CartProcessor::getCartData`, both `shipping_type_id` and `shipping_price` are included when `CartProcessor::obShippingTypeItem` is set.
But when `CartProcessor::obShippingTypeItem` is not set, only `shipping_type_id` is returned and it is fetched from database (`CartProcessor::obCart->shipping_type_id`).
`shipping_type_id` is returned as selected shipping type anyway, why don't we include shipping price according to the `shipping_type_id` as well.

Thanks!