### PR TITLE
Fix return data format of onGetData Ajax handler

### DIFF
--- a/components/Cart.php
+++ b/components/Cart.php
@@ -155,7 +155,9 @@ class Cart extends ComponentBase
      */
     public function onGetData()
     {
-        return CartProcessor::instance()->getCartData();
+        Result::setData(CartProcessor::instance()->getCartData());
+
+        return Result::get();
     }
 
     /**

--- a/components/Cart.php
+++ b/components/Cart.php
@@ -207,6 +207,15 @@ class Cart extends ComponentBase
     }
 
     /**
+     * Get cart data
+     * @return array
+     */
+    public function getData()
+    {
+        return CartProcessor::instance()->getCartData();
+    }
+
+    /**
      * Get total price string
      * @return string
      */


### PR DESCRIPTION
This PR addresses to the issue 2 in oc-shopaholic/oc-shopaholic-plugin#218.

This fixes the format of returned data of `onGetData` Ajax handler in `Cart` component.
Currently the returned data of `onGetData` does not have field such as `status`, `message`, and `code` like other Ajax handlers in the same class. This PR aligns its format with other Ajax handlers.

Also, this PR adds the same method for the use in PHP and Twig.

Thanks!