### PR TITLE
Added the ability to extend the orders toolbar

### DIFF
--- a/controllers/Orders.php
+++ b/controllers/Orders.php
@@ -10,12 +10,14 @@ use Backend\Classes\Controller;
  */
 class Orders extends Controller
 {
+    const EVENT_EXTEND_TOOLBAR = 'shopaholic.order.extendToolbar';
+
     public $implement = [
         'Backend.Behaviors.ListController',
         'Backend.Behaviors.FormController',
         'Backend.Behaviors.RelationController',
     ];
-    
+
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
     public $relationConfig = 'config_relation.yaml';

--- a/controllers/orders/_list_toolbar.htm
+++ b/controllers/orders/_list_toolbar.htm
@@ -2,4 +2,6 @@
     <a href="<?= Backend::url('lovata/ordersshopaholic/orders/create') ?>" class="btn btn-primary oc-icon-plus">
         <?= e(trans('backend::lang.form.create')) ?>
     </a>
+
+    <?= $this->fireViewEvent($this::EVENT_EXTEND_TOOLBAR) ?>
 </div>


### PR DESCRIPTION
This is a fix for issue https://github.com/oc-shopaholic/oc-orders-shopaholic-plugin/issues/116.