### PR TITLE
Fix `array to string conversion` issue 

### DIFF
--- a/classes/processor/AbstractCartPositionProcessor.php
+++ b/classes/processor/AbstractCartPositionProcessor.php
@@ -216,6 +216,7 @@ abstract class AbstractCartPositionProcessor
         /** @var CartPosition $obCartPosition */
         foreach ($obCartPositionList as $obCartPosition) {
             $arCartPositionProperty = (array) $obCartPosition->property;
+            $arCartPositionProperty = array_dot($arCartPositionProperty);
             $bCheck = (empty($arItemProperty) && empty($arCartPositionProperty))
                 || (!array_diff($arItemProperty, $arCartPositionProperty) && !array_diff($arCartPositionProperty, $arItemProperty));
             if ($bCheck) {

--- a/classes/processor/AbstractCartPositionProcessor.php
+++ b/classes/processor/AbstractCartPositionProcessor.php
@@ -205,6 +205,7 @@ abstract class AbstractCartPositionProcessor
 
         //Get item property
         $arItemProperty = (array) array_get($this->arPositionData, 'property');
+        $arItemProperty = array_dot($arItemProperty);
 
         //Get cart position list by item_id and item_type
         $obCartPositionList = CartPosition::withTrashed()->getByCart($this->obCart->id)->getByItemType($sItemType)->getByItemID($iItemID)->get();


### PR DESCRIPTION
On orders property with multidimensional array, PHP (7.3) get `array to string conversion` exception.
