### PR TITLE
Add Cart ID in cart data result array

### DIFF
--- a/classes/processor/CartProcessor.php
+++ b/classes/processor/CartProcessor.php
@@ -417,6 +417,7 @@ class CartProcessor
         $obCartPositionList = $this->get();
 
         $arResult = [
+            'id'                   => $this->obCart->id,
             'position'             => [],
             'shipping_price'       => $this->getShippingPriceData()->getData(),
             'position_total_price' => $this->getCartPositionTotalPriceData()->getData(),


### PR DESCRIPTION
Cart id required in some of ecommerce metrics systems for tracking user carts.

Example: https://www.finteza.com/ru/integrations/ecommerce/ecommerce-events#add-remove-cart