### PR TITLE
Add a setting for disabling the automatic cart clearing functionality

### DIFF
--- a/classes/event/settings/ExtendSettingsFieldHandler.php
+++ b/classes/event/settings/ExtendSettingsFieldHandler.php
@@ -108,6 +108,12 @@ class ExtendSettingsFieldHandler extends AbstractBackendFieldHandler
                 'span'  => 'left',
                 'type'  => 'checkbox',
             ],
+            'disable_cart_clear_on_new_order'       => [
+                'tab'   => 'lovata.ordersshopaholic::lang.tab.order_settings',
+                'label' => 'lovata.ordersshopaholic::lang.settings.disable_cart_clear_on_new_order',
+                'span'  => 'left',
+                'type'  => 'checkbox',
+            ],
         ]);
     }
 

--- a/classes/processor/OrderProcessor.php
+++ b/classes/processor/OrderProcessor.php
@@ -3,6 +3,7 @@
 use DB;
 use Lang;
 use Event;
+use Lovata\Shopaholic\Models\Settings;
 use October\Rain\Support\Traits\Singleton;
 
 use Kharanenka\Helper\Result;
@@ -107,7 +108,9 @@ class OrderProcessor
 
         Event::fire(self::EVENT_ORDER_CREATED, $this->obOrder);
 
-        CartProcessor::instance()->clear();
+        if (! Settings::get('disable_cart_clear_on_new_order')) {
+            CartProcessor::instance()->clear();
+        }
 
         $arResult = [
             'id'     => $this->obOrder->id,

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -128,6 +128,7 @@
         'creating_order_mail_template'         => 'Mail template of creating orders (for users)',
         'creating_order_manager_mail_template' => 'Mail template of creating orders (for managers)',
         'creating_order_manager_email_list'    => 'Managers email list',
+        'disable_cart_clear_on_new_order'      => 'Disable cart clear on new order',
 
         'order_create_email' => 'Email for sending mail when creating an order',
     ],


### PR DESCRIPTION
Some users might want to clear the cart after the payment is done instead of before. This PR adds a setting for that. Users that disable this, can manually clear the cart by using the `PaymentGateway::EVENT_PROCESS_RETURN_URL` event.