### PR TITLE
Change password generator for new users.

### DIFF
--- a/components/MakeOrder.php
+++ b/components/MakeOrder.php
@@ -339,7 +339,7 @@ class MakeOrder extends ComponentSubmitForm
             return;
         }
 
-        $sPassword = md5(microtime(true));
+        $sPassword = str_random(8);
 
         //Get user email
         if (Settings::getValue('generate_fake_email') && (!isset($this->arUserData['email']) || empty($this->arUserData['email']))) {


### PR DESCRIPTION
`md5(microtime(true));` - creates way to long password string, that is not really friendly to new customers. 
**Example: 280a9a19a0cadaa2ce4092251e065113**

`str_random(8)` - Generates 8 alphanumeric string, that is more friendly and easier to read or remember.  
**Example: Ms6epOqT**