### PR TITLE
Add recordsPerPage to ShippingTypes controller.

### DIFF
--- a/controllers/shippingtypes/config_list.yaml
+++ b/controllers/shippingtypes/config_list.yaml
@@ -3,6 +3,7 @@ modelClass: Lovata\OrdersShopaholic\Models\ShippingType
 list: $/lovata/ordersshopaholic/models/shippingtype/columns.yaml
 recordUrl: 'lovata/ordersshopaholic/shippingtypes/update/:id'
 noRecordsMessage: 'backend::lang.list.no_records'
+recordsPerPage: '25'
 showSetup: true
 showCheckboxes: true
 defaultSort:


### PR DESCRIPTION
In some circumstances, external warehouse service has deliveries for each type of products. So we have to limit controller with pagination otherwise it will die from memory leak.