### PR TITLE
Fixed an error saving promomechanism model properties

### DIFF
--- a/models/promomechanism/fields.yaml
+++ b/models/promomechanism/fields.yaml
@@ -114,23 +114,18 @@ fields:
                 value[Lovata\OrdersShopaholic\Classes\PromoMechanism\PositionCountGreater\PositionCountGreaterDiscountTotalPrice]
         span: left
         type: text
-    property:
-        type: nestedform
-        usePanelStyles: false
-        form:
-            fields:
-                shipping_type_id:
-                    label: 'lovata.ordersshopaholic::lang.field.shipping_type'
-                    commentAbove: 'lovata.ordersshopaholic::lang.promo_mechanism.shipping_type'
-                    span: left
-                    type: checkboxlist
-                    emptyOption: lovata.toolbox::lang.field.empty
-                payment_method_id:
-                    label: 'lovata.ordersshopaholic::lang.field.payment_method'
-                    commentAbove: 'lovata.ordersshopaholic::lang.promo_mechanism.payment_method'
-                    span: right
-                    type: checkboxlist
-                    emptyOption: lovata.toolbox::lang.field.empty
+    property[shipping_type_id]:
+        label: 'lovata.ordersshopaholic::lang.field.shipping_type'
+        commentAbove: 'lovata.ordersshopaholic::lang.promo_mechanism.shipping_type'
+        span: left
+        type: checkboxlist
+        emptyOption: lovata.toolbox::lang.field.empty
+    property[payment_method_id]:
+        label: 'lovata.ordersshopaholic::lang.field.payment_method'
+        commentAbove: 'lovata.ordersshopaholic::lang.promo_mechanism.payment_method'
+        span: right
+        type: checkboxlist
+        emptyOption: lovata.toolbox::lang.field.empty
     increase:
         type: partial
         path: $/lovata/ordersshopaholic/controllers/promomechanisms/_increase.htm

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -174,3 +174,5 @@
     - 'Minor fix of integration with multisite.'
 1.32.3:
     - 'Fixed weight calculation in orders. Thanks for contribution Nick Khaetsky.'
+1.32.4:
+    - 'Fixed an error saving promomechanism model properties. Remove nested form. Thanks for contribution Semen Kuznetsov (dblackCat)'


### PR DESCRIPTION
Single fields have been created for shipping and payment methods. Previously, the nested form was overwriting the rest of the properties